### PR TITLE
Prevent request from being overwritten

### DIFF
--- a/src/Router/Strategy.php
+++ b/src/Router/Strategy.php
@@ -43,7 +43,7 @@ class Strategy extends AbstractStrategy implements StrategyInterface
      */
     public function dispatch($controller, array $vars)
     {
-        $request = Request::createFromGlobals();
+        $request = $this->container->get('Symfony\Component\HttpFoundation\Request');
 
         $response = $this->invokeController($controller, array_merge(
             [$request],


### PR DESCRIPTION
The request can be modified by middlewares before being dispatched, to add informations like GeoIP, Oauth scopes, etc. `Proton\Application` stores the request in the container [during the `handle()` method](https://github.com/alexbilbie/Proton/blob/master/src/Application.php#L241), this is the request that should be dispatched to the controllers.

The fix is simply to retrieve the request from the container instead of creating a brand new request from globals in `Phprest\Router\Strategy`.
